### PR TITLE
Use OpenAI text-to-speech for Shinexa bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+TELEGRAM_TOKEN=your-telegram-bot-token
+OPENAI_API_KEY=your-openai-api-key
+# Optional voice name from OpenAI TTS: alloy, coral, etc.
+OPENAI_VOICE=alloy
+# Set this to your public HTTPS URL for webhook mode. Leave empty to use polling.
+WEBHOOK_URL=
+PORT=8443

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.env
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,17 +1,62 @@
-# Let's Write a Python Quote Bot!
+# Shinexa Telegram Voice Chatbot
 
-This repository will get you started with building a quote bot in Python. It's meant to be used along with the [Learning Lab](https://lab.github.com) intro to Python.
+Shinexa is a Telegram mini game that chats with users and replies using an AI-generated female voice from OpenAI's text-to-speech model. It transcribes incoming voice notes to keep the conversation fluid without storing personal data.
 
-When complete, you'll be able to grab random quotes from the command line, like this:
+## Features
+- Send text or voice messages and get spoken responses
+- Interactive conversations powered by ChatGPT
+- Replies delivered using OpenAI's built-in TTS voice
+- Webhook or polling operation
 
-> **$** python get-quote.py
-> 
-> Keep it logically awesome
-> 
-> **$** python get-quote.py
-> 
-> Speak like a human
+## Setup
+1. **Install dependencies**
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. **Configure environment**
+   Copy the example file and fill in your keys:
+   ```bash
+   cp .env.example .env
+   # edit .env and set TELEGRAM_TOKEN, OPENAI_API_KEY
+   ```
+   - Optionally change `OPENAI_VOICE` to another built-in name such as `coral` or `nova`.
+   - Set `WEBHOOK_URL` to your public HTTPS URL if you want webhook mode; leave blank to use polling.
+3. **Run the bot**
+   ```bash
+   python telegram_bot.py
+   ```
 
-## Start the Tutorial
+4. **Voice web demo**
+   ```bash
+   python web_server.py
+   ```
+   Then open [http://localhost:5000](http://localhost:5000) and click the microphone button to chat with Shinexa in your browser.
 
-You can find your next step in [this repo's issues](../../issues/)!
+## Webhook
+When `WEBHOOK_URL` is defined, the bot starts an HTTPS webhook and automatically registers it with Telegram. The webhook listens on `PORT` (default `8443`).
+
+## Replit Deployment
+1. Import this repository into a Replit project.
+2. Add the environment variables from `.env.example` in the **Secrets** tab.
+3. Set `WEBHOOK_URL` to the URL shown by Replit when the bot runs.
+4. Start the bot with `python telegram_bot.py` in the Replit shell.
+
+## Component Tool Suggestions
+
+| Component               | Tool Suggestions                              |
+| ----------------------- | --------------------------------------------- |
+| Content Autogenerierung | GPT-4o, ElevenLabs, D-ID, RunwayML             |
+| Scripting / Scheduling  | Python + Playwright + cron                     |
+| Analytics              | Google Analytics / Matomo / Fathom             |
+| Monitoring             | UptimeRobot + custom HTML parsers              |
+| Link-Tracking          | Bitly, T2M, self-hosted redirect servers       |
+| Payment-Logic          | Stripe webhooks (for external services)        |
+
+## Notes
+- The spoken voice is AI-generated; OpenAI does not support custom voice cloning.
+- The bot does not store user messages or audio on disk.
+
+## Running Tests
+```bash
+pytest
+```

--- a/get-quote.py
+++ b/get-quote.py
@@ -1,11 +1,11 @@
+import random
+
+
 def main():
-  # print("Keep it logically awesome.")
+    with open("quotes.txt", "r", encoding="utf-8") as f:
+        quotes = [line.strip() for line in f if line.strip()]
+    print(random.choice(quotes))
 
-  #f = open("quotes.txt")
-  #quotes = f.readlines()
-  #f.close()
 
-  #print(quotes)
-
-if __name__== "__main__":
-  main()
+if __name__ == "__main__":
+    main()

--- a/index.html
+++ b/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Shinexa</title>
+  <style>
+    body { font-family: sans-serif; margin: 2em; }
+    #chat { border: 1px solid #aaa; padding: 1em; max-width: 400px; height: 300px; overflow-y: auto; }
+  </style>
+</head>
+<body>
+  <h1>Shinexa</h1>
+  <div id="chat"></div>
+  <button id="mic">🎤 Talk to Shinexa</button>
+  <script>
+    const chatDiv = document.getElementById('chat');
+    const micBtn = document.getElementById('mic');
+
+    function appendMessage(sender, text) {
+      const p = document.createElement('p');
+      p.textContent = `${sender}: ${text}`;
+      chatDiv.appendChild(p);
+      chatDiv.scrollTop = chatDiv.scrollHeight;
+    }
+
+    function speak(text, voiceName = 'Google UK English Female', onend) {
+      const utterance = new SpeechSynthesisUtterance(text);
+      const voices = window.speechSynthesis.getVoices();
+      const voice = voices.find(v => v.name === voiceName);
+      if (voice) utterance.voice = voice;
+      if (onend) utterance.onend = onend;
+      window.speechSynthesis.speak(utterance);
+    }
+
+    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+    const recognizer = new SpeechRecognition();
+    recognizer.lang = 'en-US';
+    recognizer.onresult = async event => {
+      const transcript = event.results[0][0].transcript;
+      appendMessage('You', transcript);
+      const res = await fetch('/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: transcript })
+      });
+      const data = await res.json();
+      appendMessage('Shinexa', data.response);
+      speak(data.response, 'Google UK English Female', () => {
+        recognizer.start();
+      });
+    };
+
+    micBtn.addEventListener('click', () => {
+      speak("Hello! I'm Shinexa. Talk to me.", 'Google UK English Female', () => {
+        recognizer.start();
+      });
+    });
+
+    window.speechSynthesis.onvoiceschanged = () => window.speechSynthesis.getVoices();
+  </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+python-telegram-bot==20.7
+python-dotenv==1.0.1
+openai>=1.30.0
+pytest==7.4.4
+Flask==3.0.2

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -1,0 +1,108 @@
+import os
+import tempfile
+from io import BytesIO
+
+from dotenv import load_dotenv
+from openai import OpenAI
+from telegram import Update
+from telegram.ext import (
+    Application,
+    CommandHandler,
+    ContextTypes,
+    MessageHandler,
+    filters,
+)
+
+load_dotenv()
+
+TELEGRAM_TOKEN = os.environ.get("TELEGRAM_TOKEN")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
+OPENAI_VOICE = os.environ.get("OPENAI_VOICE", "alloy")
+WEBHOOK_URL = os.environ.get("WEBHOOK_URL")
+PORT = int(os.environ.get("PORT", "8443"))
+
+if not TELEGRAM_TOKEN:
+    raise RuntimeError("TELEGRAM_TOKEN environment variable not set")
+if not OPENAI_API_KEY:
+    raise RuntimeError("OPENAI_API_KEY environment variable not set")
+
+openai_client = OpenAI(api_key=OPENAI_API_KEY)
+
+
+def chatgpt_reply(prompt: str) -> str:
+    resp = openai_client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return resp.choices[0].message["content"].strip()
+
+
+def tts(text: str) -> bytes:
+    """Generate speech audio for the given text."""
+    with tempfile.NamedTemporaryFile(suffix=".mp3") as tmp:
+        with openai_client.audio.speech.with_streaming_response.create(
+            model="gpt-4o-mini-tts",
+            voice=OPENAI_VOICE,
+            input=text,
+        ) as response:
+            response.stream_to_file(tmp.name)
+        tmp.seek(0)
+        return tmp.read()
+
+
+def transcribe(file_path: str) -> str:
+    """Transcribe an audio file to text."""
+    with open(file_path, "rb") as f:
+        result = openai_client.audio.transcriptions.create(
+            model="whisper-1",
+            file=f,
+        )
+    return result.text.strip()
+
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text(
+        "Welcome to Shinexa! Send text or a short voice message to chat with me. Replies are in an AI-generated voice."
+    )
+
+
+async def handle_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    prompt = update.message.text
+    reply_text = chatgpt_reply(prompt)
+    audio_bytes = tts(reply_text)
+    bio = BytesIO(audio_bytes)
+    bio.name = "reply.mp3"
+    await update.message.reply_audio(audio=bio)
+
+
+async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    file = await context.bot.get_file(update.message.voice.file_id)
+    with tempfile.NamedTemporaryFile(suffix=".ogg") as tmp:
+        await file.download_to_drive(tmp.name)
+        prompt = transcribe(tmp.name)
+    reply_text = chatgpt_reply(prompt)
+    audio_bytes = tts(reply_text)
+    bio = BytesIO(audio_bytes)
+    bio.name = "reply.mp3"
+    await update.message.reply_audio(audio=bio)
+
+
+def main() -> None:
+    app = Application.builder().token(TELEGRAM_TOKEN).build()
+    app.add_handler(CommandHandler("start", start))
+    app.add_handler(MessageHandler(filters.VOICE, handle_voice))
+    app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_text))
+
+    if WEBHOOK_URL:
+        app.run_webhook(
+            listen="0.0.0.0",
+            port=PORT,
+            url_path=TELEGRAM_TOKEN,
+            webhook_url=f"{WEBHOOK_URL}/{TELEGRAM_TOKEN}",
+        )
+    else:
+        app.run_polling()
+
+
+if __name__ == "__main__":
+    main()

--- a/web_server.py
+++ b/web_server.py
@@ -1,0 +1,29 @@
+import os
+from flask import Flask, request, jsonify, send_from_directory
+from openai import OpenAI
+from dotenv import load_dotenv
+
+load_dotenv()
+
+app = Flask(__name__, static_folder='.')
+client = OpenAI()
+
+@app.get('/')
+def index():
+    return send_from_directory('.', 'index.html')
+
+@app.post('/chat')
+def chat():
+    data = request.get_json(force=True)
+    message = data.get('message', '')
+    if not message:
+        return jsonify({'response': 'I did not hear anything.'}), 400
+    completion = client.responses.create(
+        model='gpt-4o-mini',
+        input=message,
+    )
+    reply = completion.output_text
+    return jsonify({'response': reply})
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- replace ElevenLabs voice cloning with OpenAI transcription and text-to-speech
- drop per-user voice storage and simplify environment configuration
- add simple browser demo and document AI-generated voice usage
- document component tool suggestions for content generation, scheduling, analytics, monitoring, link tracking, and payments
- add microphone-driven Shinexa web demo served by a Flask backend

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile telegram_bot.py get-quote.py web_server.py`
- `python get-quote.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ff752fbfc832e87ed3ca15daf46e8