### PR TITLE
Fix OpenAI response handling in telegram bot

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -34,7 +34,19 @@ def chatgpt_reply(prompt: str) -> str:
         model="gpt-4o-mini",
         messages=[{"role": "user", "content": prompt}],
     )
-    return resp.choices[0].message["content"].strip()
+    message = resp.choices[0].message
+    content = message.content
+    if isinstance(content, list):
+        text_parts = []
+        for part in content:
+            if hasattr(part, "text"):
+                text_parts.append(part.text)
+            elif isinstance(part, dict) and "text" in part:
+                text_parts.append(part["text"])
+        content = "".join(text_parts)
+    elif content is None:
+        content = ""
+    return str(content).strip()
 
 
 def tts(text: str) -> bytes:


### PR DESCRIPTION
## Summary
- handle list or missing content returned by OpenAI responses to avoid crashes in `chatgpt_reply`

## Testing
- `python -m py_compile telegram_bot.py get-quote.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68934f68e6b0832cb047abb0d6e04850